### PR TITLE
Explain dependency into curlcpp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "vendor/liboauthcpp"]
 	path = vendor/liboauthcpp
 	url = https://github.com/sirikata/liboauthcpp.git
+[submodule "vendor/curlcpp"]
+	path = vendor/curlcpp
+	url = https://github.com/JosephP91/curlcpp.git

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 
 - `picojson` は[PicoJSON](https://github.com/kazuho/picojson)から引っ張ってきました。[2条項BSDライセンス](https://github.com/kazuho/picojson/blob/master/LICENSE) です。
 - `liboauthcpp` は[liboauthcpp](https://github.com/sirikata/liboauthcpp)から引っ張ってきました。[MITライセンス](https://github.com/sirikata/liboauthcpp/blob/master/LICENSE) です。
+- `curlcpp` は[curlcpp](https://github.com/JosephP91/curlcpp)から引っ張ってきました。[MITライセンス](https://github.com/JosephP91/curlcpp/blob/master/LICENSE) です。
 
 ## 構想
 


### PR DESCRIPTION
Without modification into `.gitmodules`, `$ git submodule init` have not been accepted.